### PR TITLE
Added support for fixed orientation.

### DIFF
--- a/Source/EasyTipView.swift
+++ b/Source/EasyTipView.swift
@@ -188,6 +188,7 @@ open class EasyTipView: UIView {
         }
         
         public struct Positioning {
+            public var fixedOrientation     = false
             public var bubbleHInset         = CGFloat(1)
             public var bubbleVInset         = CGFloat(1)
             public var textHInset           = CGFloat(10)
@@ -356,7 +357,7 @@ open class EasyTipView: UIView {
     
     @objc func handleRotation() {
         guard let sview = superview
-            , presentingView != nil else { return }
+            , presentingView != nil, !self.preferences.positioning.fixedOrientation else { return }
         
         UIView.animate(withDuration: 0.3) {
             self.arrange(withinSuperview: sview)


### PR DESCRIPTION
Setting fixedOrientation  to true fixes the problem of tip view changing location after home button is pressed or device is rotated.